### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Imports:
   MASS,
   Matrix,
   MEGENA,
+  optparse,
   randomForest (>= 4.6),
   readr,
   rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Imports:
   MEGENA,
   optparse,
   randomForest (>= 4.6),
+  reader,
   readr,
   rlang,
   Rmpi,


### PR DESCRIPTION
@PradoVarathan: Added `optparse` to the the description file to install with the package. `readr` was already in the description file. It's not installing along with the package in the docker image file? If not we may need to add explicitly in the Dockerfile?